### PR TITLE
Switching to commander for CLI parsing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,8 +2,10 @@
 // The CLI for ghlint.
 
 var chalk = require('chalk');
-var ghlint = require('./index');
+var program = require('commander');
 var util = require('util');
+var ghlint = require('./index');
+var pkg = require('./package.json');
 
 // Given the owner and name of a repo, and the results for a specific invocation of `lintRepo()`, this will print out the repo's full name (which is color coded and given an icon based on its status) and a list of its failing results (if any).
 function printResults(owner, repo, results) {
@@ -17,45 +19,46 @@ function printResults(owner, repo, results) {
   });
 }
 
-// If `--color` or `--no-color` have been used, chalk has already processed them at this point. Remove them from the args if they are still there.
-process.argv = process.argv.filter(function (arg) {
-  return !/^--(no-)?color$/i.test(arg);
-});
+program
+  .version(pkg.version)
+  .description(pkg.description)
+  .usage('[repos...]')
+  .parse(process.argv);
 
-// The query is the first argument of the ghlint command. The query can either represent a specific repo in the format "owner/repository", or an owner with just the name of the owner (which triggers the Linters for all of the owner's repositories).
-if (process.argv[2]) {
-  var query = process.argv[2].split('/');
-  var owner = query[0];
-  var repo = query[1];
-}
+if (program.args.length) {
+  program.args.forEach(function (arg) {
+    // The query is the first argument of the ghlint command. The query can either represent a specific repo in the format "owner/repository", or an owner with just the name of the owner (which triggers the Linters for all of the owner's repositories).
+    var query = arg.split('/');
+    var owner = query[0];
+    var repo = query[1];
 
-if (owner) {
-  // If a specific repo is given...
-  if (repo) {
-    ghlint.lintRepo(owner, repo, function (error, linters) {
-      if (error) {
-        console.error(error.message);
-      } else {
-        printResults(owner, repo, linters);
-      }
-    });
-  } else {
-    // If an owner is given...
-    ghlint.lintReposByOwner(owner, function (error, repos) {
-      if (error) {
-        console.error(error.message);
-      } else {
-        repos.forEach(function (repoResults, index) {
-          // Print a blank line between the results for multiple repos.
-          if (index !== 0) {
-            console.log();
-          }
-          printResults(repoResults.owner, repoResults.name, repoResults.results);
-        });
-      }
-    });
-  }
+    if (repo) {
+      // If a specific repo is given...
+      ghlint.lintRepo(owner, repo, function (error, linters) {
+        if (error) {
+          console.error(error.message);
+        } else {
+          printResults(owner, repo, linters);
+        }
+      });
+    } else if (owner) {
+      // If an owner is given...
+      ghlint.lintReposByOwner(owner, function (error, repos) {
+        if (error) {
+          console.error(error.message);
+        } else {
+          repos.forEach(function (repoResults, index) {
+            // Print a blank line between the results for multiple repos.
+            if (index !== 0) {
+              console.log();
+            }
+            printResults(repoResults.owner, repoResults.name, repoResults.results);
+          });
+        }
+      });
+    }
+  });
 } else {
   // If the repo argument is missing, show usage.
-  console.error('Usage: ghlint <repo>');
+  program.help();
 }

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
   "name": "ghlint",
-  "version": "0.9.0-alpha.1",
   "description": "A linter for GitHub projects.",
-  "main": "index.js",
+  "version": "0.9.0-alpha.1",
+  "author": "Nicolas McCurdy <thenickperson@gmail.com>",
   "bin": {
     "ghlint": "cli.js"
   },
+  "bugs": {
+    "url": "https://github.com/nicolasmccurdy/ghlint/issues"
+  },
   "dependencies": {
     "async": "^0.9.0",
-    "chalk": "^1.0.0"
+    "chalk": "^1.0.0",
+    "commander": "2.7.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",
     "nock": "^0.59.1"
   },
-  "scripts": {
-    "start": "node cli",
-    "test": "node_modules/.bin/mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nicolasmccurdy/ghlint"
-  },
+  "homepage": "https://github.com/nicolasmccurdy/ghlint",
   "keywords": [
     "github",
     "lint"
   ],
-  "author": "Nicolas McCurdy <thenickperson@gmail.com>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/nicolasmccurdy/ghlint/issues"
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nicolasmccurdy/ghlint"
   },
-  "homepage": "https://github.com/nicolasmccurdy/ghlint"
+  "scripts": {
+    "start": "node cli",
+    "test": "mocha"
+  }
 }


### PR DESCRIPTION
1. Default usage and `--help` usage:
   
   ``` sh
   $ ghlint
   
   Usage: ghlint [repos...]
   
   A linter for GitHub projects.
   
   Options:
   
     -h, --help     output usage information
     -V, --version  output the version number
   ```
2. `--version` usage:
   
   ``` sh
   $ ghlint --version
   0.9.0-alpha.1
   ```
3. Lint a single owner/repo:
   
   ``` sh
   $ ghlint nicolasmccurdy/ghlint
   ✓ nicolasmccurdy/ghlint
   ```
4. Lint all owner repos:
   
   ``` sh
   $ ghlint eslint
   ✓ eslint/eslint
   
   ✓ eslint/eslint-tester
   
   ✖ eslint/eslint.github.io
   repository name should be lowercased
   uses GitHub Pages and is missing a homepage
   
   ✓ eslint/espree
   
   ✓ eslint/generator-eslint
   ```
5. Lint multiple owner/repos:
   
   ``` sh
   $ ghlint eslint/eslint eslint/espree
   ✓ eslint/espree
   ✓ eslint/eslint
   ```

Fixes #2
